### PR TITLE
Patch for place bounds check

### DIFF
--- a/src/Runtime/Builtins.hs
+++ b/src/Runtime/Builtins.hs
@@ -41,10 +41,22 @@ builtinT = \inputT pieceT -> [
 --   We only want the latest version of each unique board, so filter out its predecessor.
 place :: [Val] -> Eval Val
 place = \[v, Vboard arr, Vt [Vi x, Vi y]] -> do
-   let b = Vboard $ arr // [((x,y), v)]
-   (tape, boards, iters) <- get
-   put (tape, filter (/= Vboard arr) boards ++ [b], iters)
-   return b
+   -- retrieve the bounds for this array
+   let (_,(x',y')) = bounds arr
+   -- verify our request to place is on the board
+   case x <= x' && y <= y' && x > 0 && y > 0 of
+     -- valid, place and return the resulting board
+     True   -> do
+                 let b = Vboard $ arr // [((x,y), v)]
+                 (tape, boards, iters) <- get
+                 put (tape, filter (/= Vboard arr) boards ++ [b], iters)
+                 return b
+     -- invalid, return a runtime error
+     False  -> return (Err $ p1 ++ p2) where
+                p1 = "Could not access (" ++ show x ++ "," ++ show y ++ ") on the board, " ++
+                  "this is not a valid space. "
+                p2 = if x' == y' && x' == 1 then "The board only has one space at (1,1)."
+                                         else "The board size is ("++ show x' ++ "," ++ show y' ++")."
 
 -- | Verifies the parameters are of the expected number & type from their respective lambdas
 -- A final case reports a Runtime error in case anything slips by,

--- a/test/EvalTests.hs
+++ b/test/EvalTests.hs
@@ -31,7 +31,8 @@ evalTests = TestList [
   testEvalLetRef,
   testEvalNextNotPresent,
   testEvalLimit,
-  testNegativeBoardAccess]
+  testNegativeBoardAccess,
+  testBadPlace]
 
 testEvalEquiv :: Test
 testEvalEquiv = TestCase (
@@ -162,3 +163,14 @@ evalTicTacToe = do
             buf        = (moves, [], 0)
             moves      = map Vt (map (\_p -> [Vi (fst _p), Vi (snd _p)]) coords)
             coords     = [(1, 1), (2, 1), (2, 2), (3, 1), (3, 3)]
+
+
+-- | Test that place function is not allowed to place outside the board
+testBadPlace :: Test
+testBadPlace = TestCase (
+  assertEqual "Tests that the 'place' function won't crash when out of bounds"
+  True
+  (let barray = array ((1,1),(1,1)) [((1,1),(Vi 1))] in
+   let _board  = Vboard barray in
+   let evalTT = runEval (Env [("b",_board)] (1,1)) ([], [], 1) in
+   isRightErr (evalTT (eval (App "place" (Tuple [(I 1),(Ref "b"),(Tuple [(I 1),(I 2)])]))))))

--- a/test/TypeCheckerTests.hs
+++ b/test/TypeCheckerTests.hs
@@ -202,7 +202,7 @@ testOneSpaceIncompleteBoardEq = TestCase (
 -- test TC on complete board
 testCompleteBoardEq :: Test
 testCompleteBoardEq = TestCase (
-  (assertBool "Verifies that an complete board equation is valid") $
+  (assertBool "Verifies that a complete board equation is valid") $
   allPassTC [testGame [(BVal (Sig "b" (Plain boardxt)) [PosDef "b" (ForAll ("x")) (ForAll ("y")) (I 1)] dummyPos)]]
   )
 


### PR DESCRIPTION
Fixes an observed issue where the `place` function did not verify the position passed was valid. This could lead to an invalid array index hit, which would crash the run and return a haskell error. This was not parsable by the frontend, and result in a obscure 'could not understand your program' error (a fallback error).

This was the same category of error as with the Get operation (ex. `b!(9,9)`). We have an existing check to prevent invalid access there, however that reports a *type error*. For the current implementation of the builtin functions, the parameters are not accessible until evaluation. We do not have an existing `OutOfBounds` error for runtime errors, so I copied over the existing error message here. This should be refined further to address the duplication. We do want this in before the start of next week, so depending on the time we have to work on this it may be something we want to note as an issue for later.

An additional test has been added to check that `place` w/ a bad position fails as expected, and this was verified to fail before the patch was put in place.