### PR TITLE
Enforces Lowercase Parameter Names

### DIFF
--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -226,7 +226,7 @@ atom' =
   <|>
   B <$> (reserved "False" *> pure False)
   <|>
-  (try $ App <$> identifier <*> (parens (formArgs <$> (commaSep1 expr))))
+  (try $ App <$> (lookAhead lower *> identifier) <*> (parens (formArgs <$> (commaSep1 expr))))
   <|>
   S <$> capIdentifier
   <|>
@@ -238,7 +238,7 @@ atom' =
   <|>
   (do
       reserved "let"
-      var <- identifier
+      var <- lookAhead lower *> identifier
       reservedOp "="
       outer <- expr
       reserved "in"
@@ -269,7 +269,7 @@ atom' =
 -- | Parse parameters
 params :: Name -> Parser [Name]
 params n = do
-   parameters <- parens $ commaSep1 identifier
+   parameters <- parens $ commaSep1 $ lookAhead lower *> identifier
    let paramSet = nub parameters
    if paramSet == parameters
       then return parameters

--- a/src/Utils/String.hs
+++ b/src/Utils/String.hs
@@ -6,7 +6,7 @@ module Utils.String where
 
 import Data.List
 
--- | Prepend l to r and append b
+-- | Prepend l to b and and append r
 surrounds :: [a] -> [a] -> [a] -> [a]
 surrounds l r b = l ++ b ++ r
 

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -37,7 +37,8 @@ parserTests = TestList [
   testMisnamedDefIsParseError1,
   testMisnamedDefIsParseError2,
   testMisnamedDefIsParseError3,
-  testMisnamedDefWithArgsIsParseError
+  testMisnamedDefWithArgsIsParseError,
+  testCasings -- casing test group
   ]
 
 --
@@ -641,3 +642,34 @@ testMisnamedDefWithArgsIsParseError = TestCase (
   assertEqual "Test that a misnamed func definition triggers a parse error"
   False
   (isRight $ parseAll (many decl) "" "t:Int -> Int\na(x)=x+1"))
+
+--
+-- Casing tests
+--
+testCasings :: Test
+testCasings = TestLabel "Casing Tests" (TestList [
+  testUppercaseParamsFail,
+  testUppercaseFunctionApplicationFails,
+  testUppercaseLetNameFails
+  ])
+
+-- | Tests that uppercase params fail to parse
+testUppercaseParamsFail :: Test
+testUppercaseParamsFail = TestCase (
+  assertEqual "Tests that uppercase params fail to parse"
+  False
+  (isRight $ parseAll (parseGame []) "" "game E\ntype T={X,O}\nf:T -> Bool\nf(X)=if X==O then True else False"))
+
+-- | Tests that uppercase params fail to parse
+testUppercaseFunctionApplicationFails :: Test
+testUppercaseFunctionApplicationFails = TestCase (
+  assertEqual "Tests that uppercase function application fails to parse"
+  False
+  (isRight $ parseAll (parseGame []) "" "game E\ntype T={X,O}\nf:T\nf=X(True)"))
+
+-- | Tests that uppercase params fail to parse
+testUppercaseLetNameFails :: Test
+testUppercaseLetNameFails = TestCase (
+  assertEqual "Tests that uppercase let params fail to parse"
+  False
+  (isRight $ parseAll (parseGame []) "" "game E\ntype T={X,O}\nf:Int\nf=let X=5 in 5"))


### PR DESCRIPTION
Closes #163, a reported issue earlier today where a student encountered the following form of parsing bug:
```haskell
game Ex

type Content = {X,O}

f : Context -> Bool
f(X) = if X == O then True else False
```
Pre-patch this generates no parse error, and returns 'False' every time as if it were a constant function. Looking into this I found that the same behavior was also present in function application (would generate a type error instead of a parse error) and the name binding associated with a let expression (which would succeed silently as well). These cases are detailed as:
```haskell
-- bad let
let X = 5 in 5

...

-- bad func app generates a type error instead of a parse error, as no function should start like this
type Content = {X,O}
X(1)
```

This patch introduces a `lookAhead lower` on all three of these instances where a new name can be bound to the environment, and enforces a leading lowercase alpha character. Failing tests for all three instances were added and verified to be corrected post-patch. As a followup, I double checked declarations for functions and value eqs, but found these to be properly verified.

@alexgrejuc this should be ready to merge, but let me know if I missed any cases where a new name can be bound that needs to be cased properly and is not. I *think* I covered everything here however.