### PR TITLE
Convert EvalEnv from List -> Map

### DIFF
--- a/examples/Scope.bgl
+++ b/examples/Scope.bgl
@@ -1,0 +1,21 @@
+-- if eleven = 11 then we have lexical-scope (good)
+-- if eleven = 20, then we have dynamic scope (bad)
+game Scope
+
+x : Int
+x = 1
+
+b : Int
+b = x
+
+f : Int -> Int
+f(x) = x + b
+
+eleven : Int
+eleven = f(10)
+
+g : Int -> Int
+g(y) = x + y
+
+eleven' : Int
+eleven' = let x = 10 in g(10)

--- a/src/Runtime/Eval.hs
+++ b/src/Runtime/Eval.hs
@@ -193,7 +193,7 @@ eval (App n es) = do
 -- evaluate a Let expression
 eval (Let n e1 e2) = do
   v <- eval e1
-  extScope (MapEvalEnv (Map.singleton n v)) (eval e2)
+  extScope (insertEvalEnv (n,v) emptyEvalEnv) (eval e2)
 
 -- evaluate an If-Then-Else expression
 eval (If p e1 e2) = do

--- a/src/Runtime/Eval.hs
+++ b/src/Runtime/Eval.hs
@@ -165,7 +165,7 @@ eval (Ref n) = do
                   -- valid reference
                   (Just v) -> case v of
                     -- Pending Value, need to eval this to get the actual value
-                    (Pv _ e') -> evalWithLimit $ eval e'
+                    (Pv env e') -> extScope env $ evalWithLimit $ eval e'
                     -- normal value, return as is
                     _         -> return $ v
                   -- invalid reference

--- a/src/Runtime/Eval.hs
+++ b/src/Runtime/Eval.hs
@@ -19,7 +19,7 @@ import Control.Monad.Writer
 import Control.Monad.State
 
 import Text.Parsec.Pos
-import qualified Data.Map.Strict as Map
+import qualified Data.Map.Strict as Map()
 
 
 -- | Produce all of the bindings from a list of value definitions.
@@ -185,8 +185,8 @@ eval (App n es) = do
     Nothing -> do
       f <- lookupName n
       case f of
-        Just (Vf params env' e) -> extScope (extendEvalEnv (params,args) env') (evalWithLimit (eval e))--(Map.union (Map.fromList (zip params (args))) env') (evalWithLimit (eval e)) -- ++ env?
-        Just (Pv env' e)        -> extScope (extendEvalEnv ([],args) env') (evalWithLimit (eval e)) --(Map.union (Map.fromList (zip [] (args))) env') (evalWithLimit (eval e)) -- ++ env?
+        Just (Vf params env' e) -> extScope (extendEvalEnv (zip params args) env') (evalWithLimit (eval e))
+        Just (Pv env' e)        -> extScope env' (evalWithLimit (eval e))
         Nothing                 -> return $ Err $ "Couldn't find " ++ n ++ " in the environment!"
         _                       -> return $ Err $ n ++ " was not correct when looking it up in the environment!"
 
@@ -214,8 +214,8 @@ eval (While c b names exprs) = do
          env <- getEnv         -- get the current environment
          result <- eval b      -- evaluate the body
          case result of        -- update the variables in the environment w/ new values and recurse:
-            (Vt vs) -> extScope (extendEvalEnv (names,vs) env) recurse --extScope (unionEvalEnv (Map.fromList (zip names vs)) env) recurse
-            r       -> extScope (insertEvalEnv (head names, r) env) recurse --extScope (unionEvalEnv (Map.fromList [(head names, r)]) env) recurse -- that head should never fail...
+            (Vt vs) -> extScope (extendEvalEnv (zip names vs) env) recurse
+            r       -> extScope (insertEvalEnv (head names, r) env) recurse -- that head should never fail...
       (Just False) -> do
         e <- eval exprs
         return e

--- a/src/Runtime/Eval.hs
+++ b/src/Runtime/Eval.hs
@@ -28,7 +28,7 @@ bindings :: (Int, Int) -> [ValDef a] -> Writer [Exception] Env
 bindings sz vs = e
   where
     e = foldM (\env (n, v) -> case runEval env ([], [], 1) v of
-                                Right v' -> return $ modifyEval (Map.union $ Map.fromList [(n, v')]) env
+                                Right v' -> return $ modifyEval (insertEvalEnv (n, v')) env
                                 Left _err -> (tell [_err]) >> return env)
         (emptyEnv sz)
         (map bind vs)
@@ -185,15 +185,15 @@ eval (App n es) = do
     Nothing -> do
       f <- lookupName n
       case f of
-        Just (Vf params env' e) -> extScope (Map.union (Map.fromList (zip params (args))) env') (evalWithLimit (eval e)) -- ++ env?
-        Just (Pv env' e)        -> extScope (Map.union (Map.fromList (zip [] (args))) env') (evalWithLimit (eval e)) -- ++ env?
+        Just (Vf params env' e) -> extScope (extendEvalEnv (params,args) env') (evalWithLimit (eval e))--(Map.union (Map.fromList (zip params (args))) env') (evalWithLimit (eval e)) -- ++ env?
+        Just (Pv env' e)        -> extScope (extendEvalEnv ([],args) env') (evalWithLimit (eval e)) --(Map.union (Map.fromList (zip [] (args))) env') (evalWithLimit (eval e)) -- ++ env?
         Nothing                 -> return $ Err $ "Couldn't find " ++ n ++ " in the environment!"
         _                       -> return $ Err $ n ++ " was not correct when looking it up in the environment!"
 
 -- evaluate a Let expression
 eval (Let n e1 e2) = do
   v <- eval e1
-  extScope (Map.singleton n v) (eval e2) --(pure (n, v))
+  extScope (MapEvalEnv (Map.singleton n v)) (eval e2)
 
 -- evaluate an If-Then-Else expression
 eval (If p e1 e2) = do
@@ -214,8 +214,8 @@ eval (While c b names exprs) = do
          env <- getEnv         -- get the current environment
          result <- eval b      -- evaluate the body
          case result of        -- update the variables in the environment w/ new values and recurse:
-            (Vt vs) -> extScope (Map.union (Map.fromList (zip names vs)) env) recurse
-            r       -> extScope (Map.union (Map.fromList [(head names, r)]) env) recurse -- that head should never fail...
+            (Vt vs) -> extScope (extendEvalEnv (names,vs) env) recurse --extScope (unionEvalEnv (Map.fromList (zip names vs)) env) recurse
+            r       -> extScope (insertEvalEnv (head names, r) env) recurse --extScope (unionEvalEnv (Map.fromList [(head names, r)]) env) recurse -- that head should never fail...
       (Just False) -> do
         e <- eval exprs
         return e

--- a/src/Runtime/Monad.hs
+++ b/src/Runtime/Monad.hs
@@ -17,7 +17,7 @@ type Eval a = StateT Buffer (ExceptT Exception (ReaderT Env (Identity))) a
 
 -- | Call-by-value semantics
 data Env = Env {
-  evalEnv :: EvalEnv  ,
+  evalEnv :: MapEvalEnv,
   boardSize :: (Int, Int)
                }
   deriving Show
@@ -27,7 +27,7 @@ getBounds :: Eval (Int, Int)
 getBounds = boardSize <$> ask
 
 -- | Uses the StateT monad to get the evaluation environment in the runtime environment
-getEnv :: Eval (EvalEnv)
+getEnv :: Eval (MapEvalEnv)
 getEnv = evalEnv <$> ask
 
 -- | Produces an empty environment for testing, and for starting evaluations
@@ -35,7 +35,7 @@ emptyEnv :: (Int,Int) -> Env
 emptyEnv x = Env emptyEvalEnv x
 
 -- | Modifies the evaluation environment, producing a new environment
-modifyEval :: (EvalEnv -> EvalEnv) -> Env -> Env
+modifyEval :: (MapEvalEnv -> MapEvalEnv) -> Env -> Env
 modifyEval f (Env e b) = Env (f e) b
 
 -- | Input buffer and display buffer.
@@ -75,7 +75,7 @@ runEval :: Env -> Buffer -> Eval a -> Either Exception a
 runEval env buf x = runIdentity (runReaderT (runExceptT (evalStateT x buf)) env)
 
 -- | Evaluate with an extended scope
-extScope :: EvalEnv -> Eval a -> Eval a
+extScope :: MapEvalEnv -> Eval a -> Eval a
 extScope env = local $ modifyEval $ unionEvalEnv env
 
 -- | Lookup a name in the environment FIXME

--- a/src/Runtime/Monad.hs
+++ b/src/Runtime/Monad.hs
@@ -10,6 +10,7 @@ import Control.Monad.Reader
 import Control.Monad.Except
 import Control.Monad.State
 import Control.Monad.Identity
+import qualified Data.Map.Strict as Map
 
 
 -- | Eval Monad transformer
@@ -32,7 +33,7 @@ getEnv = evalEnv <$> ask
 
 -- | Produces an empty environment for testing, and for starting evaluations
 emptyEnv :: (Int,Int) -> Env
-emptyEnv x = Env [] x
+emptyEnv x = Env Map.empty x
 
 -- | Modifies the evaluation environment, producing a new environment
 modifyEval :: (EvalEnv -> EvalEnv) -> Env -> Env
@@ -76,13 +77,13 @@ runEval env buf x = runIdentity (runReaderT (runExceptT (evalStateT x buf)) env)
 
 -- | Evaluate with an extended scope
 extScope :: EvalEnv -> Eval a -> Eval a
-extScope env = local (modifyEval (env++))
+extScope env = local (modifyEval (Map.union env))
 
 -- | Lookup a name in the environment FIXME
 lookupName :: Name -> Eval (Maybe Val)
 lookupName n = do
   env <- getEnv
-  case lookup n env of
+  case Map.lookup n env of
     Just v -> (return . Just) v
     Nothing -> return Nothing
 

--- a/src/Runtime/Monad.hs
+++ b/src/Runtime/Monad.hs
@@ -33,7 +33,7 @@ getEnv = evalEnv <$> ask
 
 -- | Produces an empty environment for testing, and for starting evaluations
 emptyEnv :: (Int,Int) -> Env
-emptyEnv x = Env Map.empty x
+emptyEnv x = Env emptyEvalEnv x
 
 -- | Modifies the evaluation environment, producing a new environment
 modifyEval :: (EvalEnv -> EvalEnv) -> Env -> Env
@@ -77,13 +77,13 @@ runEval env buf x = runIdentity (runReaderT (runExceptT (evalStateT x buf)) env)
 
 -- | Evaluate with an extended scope
 extScope :: EvalEnv -> Eval a -> Eval a
-extScope env = local (modifyEval (Map.union env))
+extScope env = local $ modifyEval $ unionEvalEnv env
 
 -- | Lookup a name in the environment FIXME
 lookupName :: Name -> Eval (Maybe Val)
 lookupName n = do
   env <- getEnv
-  case Map.lookup n env of
+  case lookupEvalEnv n env of
     Just v -> (return . Just) v
     Nothing -> return Nothing
 

--- a/src/Runtime/Monad.hs
+++ b/src/Runtime/Monad.hs
@@ -10,7 +10,6 @@ import Control.Monad.Reader
 import Control.Monad.Except
 import Control.Monad.State
 import Control.Monad.Identity
-import qualified Data.Map.Strict as Map
 
 
 -- | Eval Monad transformer

--- a/src/Runtime/Values.hs
+++ b/src/Runtime/Values.hs
@@ -58,7 +58,7 @@ instance RuntimeEnv EvalEnv where
 
 -- The base environment type that all other environments are built around
 emptyEvalEnv :: EvalEnv
-emptyEvalEnv = (MapEvalEnv Map.empty)
+emptyEvalEnv = MapEvalEnv Map.empty
 
 
 -- Produces an evaluation env from the base env type

--- a/src/Runtime/Values.hs
+++ b/src/Runtime/Values.hs
@@ -21,8 +21,50 @@ import qualified Data.Map.Strict as Map
 -- composed of an NxM array of 'Val'
 type Board = Array (Int, Int) Val
 
--- | Evaluation environment
-type EvalEnv = Map.Map Name Val --[(Name, Val)]
+
+-- | Typeclass for a runtime environment
+class RuntimeEnv a where
+  -- insert single key/val pair into the env
+  insertEvalEnv :: (String,Val) -> a -> a
+  -- extend an env with a tuple of keys and vals to be combined
+  extendEvalEnv :: ([String],[Val]) -> a -> a
+  -- combine two environments, producing a new env
+  unionEvalEnv  :: a -> a -> a
+  -- looks up a value in an env
+  lookupEvalEnv :: String -> a -> Maybe Val
+
+
+-- | Different kinds of evaluation environments
+data EvalEnv = ListEvalEnv [(String,Val)] -- env represented with a list
+  | MapEvalEnv (Map.Map String Val) -- env represented with a map
+  deriving(Show)
+
+
+-- | RuntimeEnv instance for EvalEnv
+instance RuntimeEnv EvalEnv where
+  insertEvalEnv pair (ListEvalEnv env) = ListEvalEnv $ pair : env
+  insertEvalEnv (k,v) (MapEvalEnv env) = MapEvalEnv $ Map.insert k v env
+
+  extendEvalEnv (keys,vals) (ListEvalEnv env) = ListEvalEnv $ (zip keys vals) ++ env
+  extendEvalEnv (keys,vals) (MapEvalEnv env) = MapEvalEnv $ Map.union (Map.fromList (zip keys vals)) env
+
+  unionEvalEnv (ListEvalEnv e1) (ListEvalEnv e2) = (ListEvalEnv $ e1 ++ e2)
+  unionEvalEnv (MapEvalEnv e1)  (MapEvalEnv e2) = MapEvalEnv $ Map.union e1 e2
+  unionEvalEnv _ _ = error "Cannot union environments of different values!"
+
+  lookupEvalEnv n (ListEvalEnv e) = lookup n e
+  lookupEvalEnv n (MapEvalEnv e) = Map.lookup n e
+
+
+-- The base environment type that all other environments are built around
+emptyEvalEnv :: EvalEnv
+emptyEvalEnv = (MapEvalEnv Map.empty)
+
+
+-- Produces an evaluation env from the base env type
+evalEnvFromList :: [(String,Val)] -> EvalEnv
+evalEnvFromList ls = extendEvalEnv (unzip ls) emptyEvalEnv
+
 
 -- | Runtime values that can be encountered
 data Val = Vi Int                      -- ^ Integer value

--- a/src/Runtime/Values.hs
+++ b/src/Runtime/Values.hs
@@ -15,13 +15,14 @@ import Data.Array
 import Data.List
 import Data.Aeson hiding (Array)
 import GHC.Generics
+import qualified Data.Map.Strict as Map
 
 -- | Representation of a Board in BoGL,
 -- composed of an NxM array of 'Val'
 type Board = Array (Int, Int) Val
 
 -- | Evaluation environment
-type EvalEnv = [(Name, Val)]
+type EvalEnv = Map.Map Name Val --[(Name, Val)]
 
 -- | Runtime values that can be encountered
 data Val = Vi Int                      -- ^ Integer value

--- a/test/EvalTests.hs
+++ b/test/EvalTests.hs
@@ -14,6 +14,7 @@ import Runtime.Values
 import Data.Array
 import Language.Types
 import Parser.Parser
+import qualified Data.Map.Strict as Map
 
 evalTests :: Test
 evalTests = TestList [
@@ -129,8 +130,8 @@ testEvalLimit :: Test
 testEvalLimit = TestCase (
   assertEqual "Test that the evaluation limit works"
   True
-  (isRightErr (let _valdef = (Vf ["x"] [] (If (Binop Less (Ref "x") (I 6000)) (App "iloop" (Tuple [(Binop Plus (Ref "x") (I 1))])) (Ref "x"))) in
-     let env    = Env [("iloop", _valdef)] (1,1) in
+  (isRightErr (let _valdef = (Vf ["x"] Map.empty (If (Binop Less (Ref "x") (I 6000)) (App "iloop" (Tuple [(Binop Plus (Ref "x") (I 1))])) (Ref "x"))) in
+     let env    = Env (Map.fromList [("iloop", _valdef)]) (1,1) in
      let buffer = ([],[],1) in
      let evalVal= eval (App "iloop" (Tuple [(I 0)])) in
      runEval env buffer evalVal)))
@@ -142,7 +143,7 @@ testNegativeBoardAccess = TestCase (
   True
   (isRightErr (let barray = array ((1,1),(1,1)) [((1,1),(Vi 1))] in
    let _board  = Vboard barray in
-   let env    = Env [("b", _board)] (1,1) in
+   let env    = Env (Map.fromList [("b", _board)]) (1,1) in
    let buffer = ([],[],1) in
    let evalVal= eval (Ref "b!(1,-1)") in
    runEval env buffer evalVal)))
@@ -187,5 +188,5 @@ testBadPlace = TestCase (
   True
   (let barray = array ((1,1),(1,1)) [((1,1),(Vi 1))] in
    let _board  = Vboard barray in
-   let evalTT = runEval (Env [("b",_board)] (1,1)) ([], [], 1) in
+   let evalTT = runEval (Env (Map.fromList [("b",_board)]) (1,1)) ([], [], 1) in
    isRightErr (evalTT (eval (App "place" (Tuple [(I 1),(Ref "b"),(Tuple [(I 1),(I 2)])]))))))

--- a/test/EvalTests.hs
+++ b/test/EvalTests.hs
@@ -14,7 +14,7 @@ import Runtime.Values
 import Data.Array
 import Language.Types
 import Parser.Parser
-import qualified Data.Map.Strict as Map
+import qualified Data.Map.Strict as Map()
 
 evalTests :: Test
 evalTests = TestList [

--- a/test/EvalTests.hs
+++ b/test/EvalTests.hs
@@ -130,8 +130,8 @@ testEvalLimit :: Test
 testEvalLimit = TestCase (
   assertEqual "Test that the evaluation limit works"
   True
-  (isRightErr (let _valdef = (Vf ["x"] Map.empty (If (Binop Less (Ref "x") (I 6000)) (App "iloop" (Tuple [(Binop Plus (Ref "x") (I 1))])) (Ref "x"))) in
-     let env    = Env (Map.fromList [("iloop", _valdef)]) (1,1) in
+  (isRightErr (let _valdef = (Vf ["x"] emptyEvalEnv (If (Binop Less (Ref "x") (I 6000)) (App "iloop" (Tuple [(Binop Plus (Ref "x") (I 1))])) (Ref "x"))) in
+     let env    = Env (evalEnvFromList [("iloop", _valdef)]) (1,1) in
      let buffer = ([],[],1) in
      let evalVal= eval (App "iloop" (Tuple [(I 0)])) in
      runEval env buffer evalVal)))
@@ -143,7 +143,7 @@ testNegativeBoardAccess = TestCase (
   True
   (isRightErr (let barray = array ((1,1),(1,1)) [((1,1),(Vi 1))] in
    let _board  = Vboard barray in
-   let env    = Env (Map.fromList [("b", _board)]) (1,1) in
+   let env    = Env (evalEnvFromList [("b", _board)]) (1,1) in
    let buffer = ([],[],1) in
    let evalVal= eval (Ref "b!(1,-1)") in
    runEval env buffer evalVal)))
@@ -188,5 +188,5 @@ testBadPlace = TestCase (
   True
   (let barray = array ((1,1),(1,1)) [((1,1),(Vi 1))] in
    let _board  = Vboard barray in
-   let evalTT = runEval (Env (Map.fromList [("b",_board)]) (1,1)) ([], [], 1) in
+   let evalTT = runEval (Env (evalEnvFromList [("b",_board)]) (1,1)) ([], [], 1) in
    isRightErr (evalTT (eval (App "place" (Tuple [(I 1),(Ref "b"),(Tuple [(I 1),(I 2)])]))))))

--- a/test/EvalTests.hs
+++ b/test/EvalTests.hs
@@ -1,4 +1,4 @@
-module EvalTests (evalTests, evalTicTacToe, evalWhile) where
+module EvalTests (evalTests, evalTicTacToe, evalWhile, evalScope) where
 --
 -- EvalTests.hs
 --
@@ -167,6 +167,12 @@ evalWhile = evalFile (examplesPath ++ "While.bgl") vs ([], [], 0)
             ("tenOne", Vt [Vi 10, Vi 1]), ("ten4", Vi 10), ("thirty", Vi 30), ("twenty", Vi 20),
             ("eleven", Vi 11), ("five", Vi 5), ("fifteen", Vi 15), ("twentyNine", Vi 29)]
 
+-- | Evaluates many different expressions that contain while loops
+evalScope :: IO [(Bool, String, String)]
+evalScope = evalFile (examplesPath ++ "Scope.bgl") vs ([], [], 0)
+   where
+      vs = [("eleven", Vi 11), ("eleven'", Vi 11)]
+
 -- | Takes a file name, buffer, [(veq names, expected values)]
 --   parses the file, evaluates the veqs and returns the result and some information
 evalFile :: String -> [(String, Val)] -> Buffer -> IO [(Bool, String, String)]
@@ -177,8 +183,8 @@ evalFile fn l buf = do
       (Right (Game _ (BoardDef (szx, szy) _) _ vs)) -> return $ map check l
          where
             check (eqName, expected) = case run (Ref eqName) of
-                           (Right (_, actual)) -> (expected == actual, eqName, show actual)
-                           e              -> (False, eqName, show e)
+                     (Right (_, actual)) -> (expected == actual, fn ++ ":" ++ eqName, show actual)
+                     e              -> (False, fn ++ ":" ++ eqName, show e)
             run = runWithBuffer (bindings_ (szx, szy) vs) buf
 
 -- | Test that place function is not allowed to place outside the board

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -18,10 +18,11 @@ main =  do
   tcResult    <- typeCheckAllExamples  -- Custom test: tc all examples, return Pass | (Fail #failures #errors)
   falsePos    <- typeCheckIll
   (tttR, msg) <- evalTicTacToe
-  whileR <- evalWhile
-  let badWhiles = filter (not . \(b, _, _) -> b) whileR
-  let failed = or [(errors result) > 0, (failures result) > 0, not $ parsePassed parseResult, not $ tcPassed tcResult, falsePos > 0, not tttR, (not . null) badWhiles]
+  whileR      <- evalWhile
+  scopeR      <- evalScope
+  let badEvals = filter (not . \(b, _, _) -> b) (whileR ++ scopeR)
+  let failed = or [(errors result) > 0, (failures result) > 0, not $ parsePassed parseResult, not $ tcPassed tcResult, falsePos > 0, not tttR, (not . null) badEvals]
   putStrLn ("\n\n" ++ show tcResult ++ "\n\n" ++ show parseResult ++ "\n") -- print example TC/Parse results for verification
   putStrLn $ "Evaluating tic tac toe led to: " ++ msg
-  if (not . null) badWhiles then putStrLn ("Bad while cases: \n" ++ (show badWhiles)) else return ()
+  if (not . null) badEvals then putStrLn ("Bad eval cases: \n" ++ (show badEvals)) else return ()
   if failed then exitFailure else exitSuccess


### PR DESCRIPTION
Closes #161. Initial workings converting the runtime env to a Map. These changes need scrutinizing:
- Converted the type synonym for `EvalEnv` to a separate data type, with constructors for List and Map based envs respectively.
- Adds `RuntimeEnv` typeclass that describes operations that can be performed on an env
    - `insertEvalEnv`
    - `extendEvalEnv`
    - `unionEvalEnv`
    - `lookupEvalEnv`

The base for producing all environments is `emptyEvalEnv`. Changing this changes the base type of the env in all cases.
