### PR TITLE
Removes unpackBool, BinOps Propagate Errors

### DIFF
--- a/src/Error/RuntimeError.hs
+++ b/src/Error/RuntimeError.hs
@@ -1,0 +1,31 @@
+{-|
+Description : Data type for reporting runtime errors
+-}
+
+module Error.RuntimeError where
+
+import Utils.String
+
+data RuntimeError = DivideByZero
+                  | InvalidBoardAccess (Int,Int) (Int,Int) -- ?
+                  | BadComparison String String
+                  | BadNumericalOp String String
+                  | UndefinedReference String
+                  | InvalidLookup String
+                  | StackOverflow -- runtime evaluation stack overflow
+                  | UnexpectedEvaluation String -- placeholder until we know these are caught at the type level
+
+instance Show RuntimeError where
+  show DivideByZero             = "Cannot divide by zero"
+  show (InvalidBoardAccess (x,y) (bx,by)) = p1 ++ p2
+    where
+       p1 = "Could not access (" ++ show x ++ "," ++ show y ++ ") on the board, " ++
+         "this is not a valid space. "
+       p2 = if bx == by && bx == 1 then "The board only has one space at (1,1)."
+                                   else "The board size is ("++ show bx ++ "," ++ show by ++")."
+  show (BadComparison a b)      = "Could not compare " ++ a ++ " to " ++ b
+  show (BadNumericalOp a b)     = "Could not do numerical operation on " ++ a ++ " to " ++ b
+  show (UndefinedReference s)   = (quote s) ++ " is undefined"
+  show (InvalidLookup s)        = s ++ " was not correct when looking it up in the environment."
+  show StackOverflow            = "Evaluating your expression was stopped for taking too long or being infinite."
+  show (UnexpectedEvaluation s) = s

--- a/src/Runtime/Eval.hs
+++ b/src/Runtime/Eval.hs
@@ -11,6 +11,7 @@ import Language.Syntax
 import Runtime.Values
 import Runtime.Monad
 import Runtime.Builtins
+import Error.RuntimeError
 
 import Control.Monad
 import Data.Array
@@ -55,13 +56,16 @@ bind (BVal (Sig n _) defs _) = (n, do
       values <- mapM (eval . boardExpr) defs
       maybeBoard <- lookupName n
       case maybeBoard of
+         -- no board in the envs
          Nothing         -> return $ Vboard (fill (newBoard sz) sz defs values)
+         -- existing board in the env
          Just (Vboard b) -> return $ Vboard (fill b sz defs values)
-         _ -> error "TODO")
-   where
-      newBoard sz = array ((1,1), sz)
-                    (zip [(x,y) | x <- [1..(fst sz)], y <- [1..(snd sz)]] (repeat (Vs "?")))
-      fill _board sz ds vs = foldl (\b p -> updateBoard b sz (fst p) (snd p)) _board (zip ds vs)
+         -- lookup error
+         _               -> throwRuntimeError (InvalidLookup n))
+     where
+        newBoard sz = array ((1,1), sz)
+                      (zip [(x,y) | x <- [1..(fst sz)], y <- [1..(snd sz)]] (repeat (Vs "?")))
+        fill _board sz ds vs = foldl (\b p -> updateBoard b sz (fst p) (snd p)) _board (zip ds vs)
 
 -- | Updates a board
 updateBoard :: Board -> (Int, Int) -> (BoardEq a) -> Val -> Board
@@ -77,16 +81,11 @@ posMatches xp yp (x, y) = match xp x && match yp y
 
 -- | Attempt to access a position on the board that may be invalid
 -- If the position is invalid, return an Err value instead of causing an actual array access error
-tryUnsafeBoardAccess :: (Int,Int) -> Board -> Val
+tryUnsafeBoardAccess :: (Int,Int) -> Board -> Eval Val
 tryUnsafeBoardAccess (x,y) arr = let (_,(bx,by)) = bounds arr in
    case (x < 1 || x > bx || y < 1 || y > by) of
-     False -> arr ! (x,y) -- good index
-     True  -> Err $ p1 ++ p2
-         where
-            p1 = "Could not access (" ++ show x ++ "," ++ show y ++ ") on the board, " ++
-              "this is not a valid space. "
-            p2 = if bx == by && bx == 1 then "The board only has one space at (1,1)."
-                                     else "The board size is ("++ show bx ++ "," ++ show by ++")."
+     False -> return $ arr ! (x,y) -- good index
+     True  -> throwRuntimeError $ InvalidBoardAccess (x,y) (bx,by)
 
 -- | Binary operation evaluation
 evalBinOp :: Op -> (Expr a) -> (Expr a) -> Eval Val
@@ -105,22 +104,15 @@ evalBinOp Get l r      = do
    _board <- eval l
    pos    <- eval r
    case (_board, pos) of
-      (Vboard arr, Vt [Vi x, Vi y]) -> return $ tryUnsafeBoardAccess (x,y) arr
-      -- verify neither the left or right is an error
-      (Err el, _)                   -> return $ Err el
-      (_, Err er)                   -> return $ Err er
-      _ -> return $ Err $ "Could not access " ++ show r ++ " on the board \n" ++ show l
+      (Vboard arr, Vt [Vi x, Vi y]) -> tryUnsafeBoardAccess (x,y) arr
+      _                             -> throwRuntimeError (UnexpectedEvaluation $ "Could not access " ++ show r ++ " on the board \n" ++ show l)
 
 -- | evaluates the == and /= operations
 evalEq :: (Val -> Val -> Bool) -> (Expr a) -> (Expr a) -> Eval Val
 evalEq f l r = do
                   v1 <- eval l
                   v2 <- eval r
-                  case (v1, v2) of
-                    -- verify neither the left or right is an error
-                    (Err el, _) -> return $ Err el
-                    (_, Err er) -> return $ Err er
-                    (_,_)       -> return $ Vb (f v1 v2)
+                  return $ Vb (f v1 v2)
 
 -- | evaluates comparison operations for only Ints (except for == & /=)
 evalCompareOpInt :: (Int -> Int -> Bool) -> (Expr a) -> (Expr a) -> Eval Val
@@ -129,10 +121,7 @@ evalCompareOpInt f l r = do
                      v2 <- eval r
                      case (v1, v2) of
                         (Vi l', Vi r')  -> return (Vb (f l' r'))
-                        -- verify neither the left or right is an error
-                        (Err el, _)     -> return $ Err el
-                        (_, Err er)     -> return $ Err er
-                        _               -> return $ Err $ "Could not compare " ++ show l ++ " to " ++ show r
+                        _               -> throwRuntimeError $ BadComparison (show l) (show r)
 
 -- | evaluates numerical operations
 evalNumOp :: String -> (Int -> Int -> Int) -> (Expr a) -> (Expr a) -> Eval Val
@@ -143,13 +132,9 @@ evalNumOp sym f l r =
         case (v1, v2) of
           -- if div/mod and denominator is 0, report an error, otherwise proceed
           (Vi l', Vi r') -> if r' == 0 && (sym == "/" || sym == "%")
-                              then return (Err "Cannot divide by zero")
+                              then throwRuntimeError DivideByZero -- err "Cannot divide by zero" --return (Err "Cannot divide by zero") --
                               else return (Vi (f l' r'))
-          -- verify neither the left or right is an error
-          (Err el, _)    -> return $ Err el
-          (_, Err er)    -> return $ Err er
-          _  -> return $
-                  Err $ "Could not do numerical operation on " ++ (show l) ++ " to " ++ (show r)
+          _              -> throwRuntimeError $ BadNumericalOp (show l) (show r)
 
 -- | Evaluates an expression at runtime, producing a Val in the Eval monad
 eval :: (Expr a) -> Eval Val
@@ -180,8 +165,8 @@ eval (Ref n) = do
                     (Pv _ e') -> evalWithLimit $ eval e'
                     -- normal value, return as is
                     _         -> return $ v
-                  -- invalid reference
-                  _ -> return $ Err $ "Variable " ++ n ++ " undefined"
+                  --  undefined reference
+                  _ -> throwRuntimeError (UndefinedReference n)
 
 -- evalute a function application
 eval (App n es) = do
@@ -199,8 +184,8 @@ eval (App n es) = do
       case f of
         Just (Vf params env' e) -> extScope (zip params (args) ++ env') (evalWithLimit (eval e)) -- ++ env?
         Just (Pv env' e)        -> extScope (zip [] (args) ++ env') (evalWithLimit (eval e)) -- ++ env?
-        Nothing                 -> return $ Err $ "Couldn't find " ++ n ++ " in the environment!"
-        _                       -> return $ Err $ n ++ " was not correct when looking it up in the environment!"
+        Nothing                 -> throwRuntimeError (UndefinedReference n)
+        _                       -> throwRuntimeError (InvalidLookup n)
 
 -- evaluate a Let expression
 eval (Let n e1 e2) = do
@@ -212,8 +197,7 @@ eval (If p e1 e2) = do
   mb <- eval p
   case mb of
     (Vb bb)      -> if bb then evalWithLimit $ eval e1 else evalWithLimit $ eval e2
-    er2@(Err _)  -> return er2
-    _            -> return $ Err e
+    _            -> throwRuntimeError (UnexpectedEvaluation e)
       where e = "The expression " ++ show p ++ " did not evaluate to a Bool as expected!"
 
 -- evaluate a BinOp expression
@@ -233,13 +217,14 @@ eval (While c b names exprs) = do
         e <- eval exprs
         return e
       er2@(Err _)  -> return er2  -- propagate any error produced by the condition
-      _            -> return $ Err $ "The expression " ++ show c ++
-                                     " did not evaluate to a Bool as expected!"
+      _            -> throwRuntimeError (UnexpectedEvaluation $ "The expression " ++ show c ++
+                                     " did not evaluate to a Bool as expected!")
    where
       recurse = evalWithLimit $ eval (While c b names exprs)
 
 -- evaluate a type hole
-eval (HE _) = err ("Type hole: ")
+-- TODO, we don't have type holes in BoGL anymore, phase this out
+eval (HE _) = throwRuntimeError (UnexpectedEvaluation "Type hole: ") -- type hole...
 
 -- | Runs an expression under a given environment and a given buffer, producing
 -- a result of either a list of values and a buffer, or a list of values and a single value
@@ -250,8 +235,6 @@ runWithBuffer env buf e = do
       Left (NeedInput bs) -> Left (bs, buf)
       Right (boards, val) -> Right (boards, val)
       Left (Error er)     -> Right $ ([], Err er) -- not good
-      -- TODO REMOVED REDUNDANT
-      --Left er             -> Right $ ([], Err ("Bad Error (Not Good): " ++ (show er))) -- not good
    where
       eval' :: (Expr a) -> Eval ([Val], Val)
       eval' expr = do

--- a/src/Runtime/Monad.hs
+++ b/src/Runtime/Monad.hs
@@ -101,8 +101,3 @@ readTape = do
   case tape of
     (x:xs) -> (put (xs, boards, iters)) >> return x
     [] -> waitForInput boards
-
--- | Helper function to get the Bool out of a value. This is a partial function.
-unpackBool :: Val -> Maybe Bool
-unpackBool (Vb b) = Just b  -- Just a boolean
-unpackBool _      = Nothing -- Not a valid boolean, should trip a runtime error

--- a/test/EvalTests.hs
+++ b/test/EvalTests.hs
@@ -130,11 +130,11 @@ testEvalNextNotPresent = TestCase (
 testEvalLimit :: Test
 testEvalLimit = TestCase (
   assertBool "Test that the evaluation limit works"
-  (isRightErr (let _valdef = (Vf ["x"] [] (If (Binop Less (Ref "x") (I 6000)) (App "iloop" (Tuple [(Binop Plus (Ref "x") (I 1))])) (Ref "x"))) in
+  (matchesRuntimeError (let _valdef = (Vf ["x"] [] (If (Binop Less (Ref "x") (I 6000)) (App "iloop" (Tuple [(Binop Plus (Ref "x") (I 1))])) (Ref "x"))) in
      let env    = Env [("iloop", _valdef)] (1,1) in
      let buffer = ([],[],1) in
      let evalVal= eval (App "iloop" (Tuple [(I 0)])) in
-     runEval env buffer evalVal)))
+     runEval env buffer evalVal) StackOverflow))
 
 -- | Tests that negative board access doesn't crash out things
 testNegativeBoardAccess :: Test

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -384,7 +384,6 @@ testCheckUpdatedBoard = TestCase (
   (parseAll xtype "" "(Board, (Int, Int))" == Right (Tup [X Board S.empty, Tup [X Itype S.empty, X Itype S.empty]])))
 
 
--- TODO used to be --"Right (Symbol(no extension),Board(no extension))"
 -- | Determine whether a symbol and board can be evaluated
 testCheckUpdatedBoard2 :: Test
 testCheckUpdatedBoard2 = TestCase (

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -11,10 +11,13 @@ import Parser.Parser
 import Text.Parsec.Error
 import System.Directory
 import System.FilePath
+import Error.RuntimeError
 
 import Language.Types
 import Language.Syntax
 import Text.Parsec.Pos
+
+import Debug.Trace
 
 -- | The boilerplate for a Game which is to be filled in with ValDefs
 testGame :: [ValDef SourcePos] -> Game SourcePos
@@ -39,10 +42,24 @@ getExampleFiles = do
 evalTest :: Eval Val -> Either Exception Val
 evalTest ev = runEval (emptyEnv (0,0)) ([], [], 1) ev
 
+-- Verifies a Value Error (not an exception) was produced during a computation
 isRightErr :: Either Exception Val -> Bool
 isRightErr m = case m of
                 Right (Err _) -> True
                 _             -> False
+
+-- | Used to verify an exception matches explicitly, with the provided string message
+{-
+isExceptionWithString :: Either Exception Val -> String -> Bool
+isExceptionWithString m s = case m of
+                            Left (Error e) -> trace ("Error was " ++ e) e == s
+                            _              -> False
+-}
+
+matchesRuntimeError :: Either Exception Val -> RuntimeError -> Bool
+matchesRuntimeError m re = case m of
+                            Left (Error e) -> trace ("Error was " ++ e) $ show re == e
+                            _              -> False
 
 -- | Read a single line and return the result (intended for brevity in test cases)
 parseLine' :: Parser a -> String -> Either ParseError a


### PR DESCRIPTION
Closes #158. This was reported by Dr. Parham-Mocello earlier today in a different form than previously observed.

This removes the `unpackBool` helper function, and directly changes **if-then-else** and **while** to inspect the results of evaluating their conditions directly. The use of unpack bool was redundant, as there was no reason these functions could not inspect the values themselves. In addition, it discarded the result of anything other than a bool, meaning that runtime errors were discarded as well. This allows the result of the condition to be handled appropriately, and for any errors in either the left or right sub-expressions to be propagated.

Furthermore it was observed that the `evalEq` helper function for the binops **==** and **/=** did not verify that both expressions did not evaluate to non-error values. This change verifies that both the left and right expressions evaluate to non-error values before running the comparison function on them. This error forwarding check was added to the `evalNumOp` and `evalCompareOpInt` helper functions as well. These did report errors, but created a new error regardless of the result of any of the sub-expressions, effectively discarding the old error message.

Tests targeting the 3 BinOp helper functions were written. Only 1 was failing before, but I wanted to guard against any mistakes during future refactors, as this was easy to miss.